### PR TITLE
RakutenService内リスト取得メソッド追加

### DIFF
--- a/Classes/AppDelegate.cpp
+++ b/Classes/AppDelegate.cpp
@@ -1,6 +1,7 @@
 #include "AppDelegate.h"
 #include "AppMacro.h"
 #include "LoadingScene.hpp"
+#include "RakutenService.hpp"// ダミー実装入っているか確認 TODO 消す
 
 USING_NS_CC;
 
@@ -53,7 +54,16 @@ bool AppDelegate::applicationDidFinishLaunching()
     fileUtiles->addSearchPath("res/rakuranUI/Resources/res");
     fileUtiles->addSearchPath("res/rakuranUI/Resources/res/fonts");
     fileUtiles->addSearchPath("res/rakuranUI/Resources/res/images");
-
+    
+    // ダミー実装入っているか確認 TODO 消す
+    auto rakutenService = RakutenService::getInstance();
+    auto list = rakutenService->getSampleListInfo();
+    
+    for (int i = 0; i < 30; i++)
+    {
+        LOG("idx %d = rank %d title: %s", list[i].idx,list[i].rank,list[i].title.c_str());
+    } //TODO ここまで消す
+    
     // create a scene. it's an autorelease object
     auto scene = LoadingScene::createScene();
 

--- a/Classes/AppDelegate.cpp
+++ b/Classes/AppDelegate.cpp
@@ -1,7 +1,6 @@
 #include "AppDelegate.h"
 #include "AppMacro.h"
 #include "LoadingScene.hpp"
-#include "RakutenService.hpp"// ダミー実装入っているか確認 TODO 消す
 
 USING_NS_CC;
 
@@ -54,16 +53,7 @@ bool AppDelegate::applicationDidFinishLaunching()
     fileUtiles->addSearchPath("res/rakuranUI/Resources/res");
     fileUtiles->addSearchPath("res/rakuranUI/Resources/res/fonts");
     fileUtiles->addSearchPath("res/rakuranUI/Resources/res/images");
-    
-    // ダミー実装入っているか確認 TODO 消す
-    auto rakutenService = RakutenService::getInstance();
-    auto list = rakutenService->getSampleListInfo();
-    
-    for (int i = 0; i < 30; i++)
-    {
-        LOG("idx %d = rank %d title: %s", list[i].idx,list[i].rank,list[i].title.c_str());
-    } //TODO ここまで消す
-    
+
     // create a scene. it's an autorelease object
     auto scene = LoadingScene::createScene();
 

--- a/Classes/app/service/RakutenService.cpp
+++ b/Classes/app/service/RakutenService.cpp
@@ -40,17 +40,17 @@ const std::vector<RankInfoDTO> RakutenService::getSampleListInfo()
         std::uniform_real_distribution<float> randFactor(std::min<float>(min, max), std::max<float>(min, max));
         return randFactor(mt);
     };
-    
+
     std::vector<RankInfoDTO> list;
-    
+
     for (int i = 1; i <= 30; ++i)
     {
         RankInfoDTO dto;
-        dto.idx            = i;
-        dto.rank = getRandomReal(1, 30);
-        dto.title          = cocos2d::StringUtils::format("idx[%d] rank[%d]", dto.idx, dto.rank);
+        dto.idx   = i;
+        dto.rank  = getRandomReal(1, 30);
+        dto.title = cocos2d::StringUtils::format("idx[%d] rank[%d]", dto.idx, dto.rank);
         list.push_back(dto);
     }
-    
+
     return list;
 }

--- a/Classes/app/service/RakutenService.cpp
+++ b/Classes/app/service/RakutenService.cpp
@@ -31,7 +31,7 @@ void RakutenService::destroy()
  * TODO
  * 一旦ダミー実装
  */
-const std::vector<RankInfoDTO> RakutenService::getSampleListInfo()
+const std::vector<RankInfoDTO> RakutenService::getListRankInfoDTO()
 {
     // min,maxの範囲の乱数を取得するラムダ
     auto getRandomReal = [](const float min, const float max) {

--- a/Classes/app/service/RakutenService.cpp
+++ b/Classes/app/service/RakutenService.cpp
@@ -26,3 +26,31 @@ RakutenService* RakutenService::getInstance()
 void RakutenService::destroy()
 {
 }
+
+/**
+ * TODO
+ * 一旦ダミー実装
+ */
+const std::vector<RankInfoDTO> RakutenService::getSampleListInfo()
+{
+    // min,maxの範囲の乱数を取得するラムダ
+    auto getRandomReal = [](const float min, const float max) {
+        std::random_device rnd;        // 非決定的な乱数生成器でシード生成機を生成
+        std::mt19937       mt(rnd());  //  メルセンヌツイスターの32ビット版、引数は初期シード
+        std::uniform_real_distribution<float> randFactor(std::min<float>(min, max), std::max<float>(min, max));
+        return randFactor(mt);
+    };
+    
+    std::vector<RankInfoDTO> list;
+    
+    for (int i = 1; i <= 30; ++i)
+    {
+        RankInfoDTO dto;
+        dto.idx            = i;
+        dto.rank = getRandomReal(1, 30);
+        dto.title          = cocos2d::StringUtils::format("idx[%d] rank[%d]", dto.idx, dto.rank);
+        list.push_back(dto);
+    }
+    
+    return list;
+}

--- a/Classes/app/service/RakutenService.cpp
+++ b/Classes/app/service/RakutenService.cpp
@@ -31,7 +31,7 @@ void RakutenService::destroy()
  * TODO
  * 一旦ダミー実装
  */
-const std::vector<RankInfoDTO> RakutenService::getListRankInfoDTO()
+const std::vector<RankInfoDTO> RakutenService::getRankInfoDTOList()
 {
     // min,maxの範囲の乱数を取得するラムダ
     auto getRandomReal = [](const float min, const float max) {

--- a/Classes/app/service/RakutenService.hpp
+++ b/Classes/app/service/RakutenService.hpp
@@ -24,7 +24,7 @@ class RakutenService
     static void            destroy();
     static RakutenService* _instance;
 
-    const std::vector<RankInfoDTO> getListRankInfoDTO();
+    const std::vector<RankInfoDTO> getRankInfoDTOList();
 
   private:
     RakutenService();

--- a/Classes/app/service/RakutenService.hpp
+++ b/Classes/app/service/RakutenService.hpp
@@ -8,8 +8,8 @@
 #ifndef __rakuran__RakutenService__
 #define __rakuran__RakutenService__
 
-#include "cocos2d.h"
 #include "RankInfoDTO.h"
+#include "cocos2d.h"
 
 using namespace cocos2d;
 
@@ -23,7 +23,7 @@ class RakutenService
     static RakutenService* getInstance();
     static void            destroy();
     static RakutenService* _instance;
-    
+
     const std::vector<RankInfoDTO> getSampleListInfo();
 
   private:

--- a/Classes/app/service/RakutenService.hpp
+++ b/Classes/app/service/RakutenService.hpp
@@ -9,6 +9,7 @@
 #define __rakuran__RakutenService__
 
 #include "cocos2d.h"
+#include "RankInfoDTO.h"
 
 using namespace cocos2d;
 
@@ -22,6 +23,8 @@ class RakutenService
     static RakutenService* getInstance();
     static void            destroy();
     static RakutenService* _instance;
+    
+    const std::vector<RankInfoDTO> getSampleListInfo();
 
   private:
     RakutenService();

--- a/Classes/app/service/RakutenService.hpp
+++ b/Classes/app/service/RakutenService.hpp
@@ -24,7 +24,7 @@ class RakutenService
     static void            destroy();
     static RakutenService* _instance;
 
-    const std::vector<RankInfoDTO> getSampleListInfo();
+    const std::vector<RankInfoDTO> getListRankInfoDTO();
 
   private:
     RakutenService();


### PR DESCRIPTION
# issue
[#8](https://github.com/noviceky/rakuten/issues/8)
# 変更内容
RakutenService::getSampleListInfo()の追加→(getListRankInfoDTOに名称変更)
AppDelegate内で取得テスト(削除)